### PR TITLE
ci: add baseline CI and Gemini security workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI (Public Baseline)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Ruff lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install Ruff
+        run: |
+          python -m pip install --upgrade pip
+          pip install "ruff>0.1.7"
+      - name: Run Ruff
+        run: ruff check --output-format=github
+
+  typecheck:
+    name: Pyright typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: latest
+      - name: Install dependencies
+        run: uv sync --all-extras
+      - name: Run Pyright (core)
+        run: uv run pyright ./graphiti_core
+      - name: Install graph-service dependencies
+        run: |
+          cd server
+          uv sync --all-extras
+      - name: Run Pyright (server)
+        run: |
+          cd server
+          uv run pyright .
+
+  tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: latest
+      - name: Install dependencies
+        run: uv sync --all-extras
+      - name: Run unit tests (no external deps)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          DISABLE_NEPTUNE: 1
+          DISABLE_NEO4J: 1
+          DISABLE_FALKORDB: 1
+          DISABLE_KUZU: 1
+        run: |
+          uv run pytest tests/ -m "not integration" \
+            --ignore=tests/test_graphiti_int.py \
+            --ignore=tests/test_graphiti_mock.py \
+            --ignore=tests/test_node_int.py \
+            --ignore=tests/test_edge_int.py \
+            --ignore=tests/test_entity_exclusion_int.py \
+            --ignore=tests/driver/ \
+            --ignore=tests/llm_client/test_anthropic_client_int.py \
+            --ignore=tests/utils/maintenance/test_temporal_operations_int.py \
+            --ignore=tests/cross_encoder/test_bge_reranker_client_int.py \
+            --ignore=tests/evals/

--- a/.github/workflows/gemini-security.yml
+++ b/.github/workflows/gemini-security.yml
@@ -1,0 +1,44 @@
+name: Gemini Security
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: gemini-security-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gemini-security:
+    if: ${{ secrets.GEMINI_API_KEY != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Gemini security analysis
+        uses: google-github-actions/run-gemini-cli@v0.1.20
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || '' }}
+          REPOSITORY: ${{ github.repository }}
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          gemini_cli_version: '0.26.0'
+          extensions: |
+            [
+              "https://github.com/gemini-cli-extensions/security.git"
+            ]
+          prompt: /security:analyze-github-pr
+
+  gemini-security-skipped:
+    if: ${{ secrets.GEMINI_API_KEY == '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip notice
+        run: |
+          echo "Skipping Gemini Security: repository secret GEMINI_API_KEY is not configured."

--- a/prd/EXEC-CI-GEMINI-WORKFLOWS-v1.md
+++ b/prd/EXEC-CI-GEMINI-WORKFLOWS-v1.md
@@ -1,0 +1,49 @@
+# PRD: Add Baseline CI + Gemini Security Workflows v1
+
+## PRD Metadata
+- Type: Execution
+- Kanban Task: task-graphiti-publicization-upstream-sync
+- Parent Epic: task-graphiti-publicization-upstream-sync
+- Depends On: PR #1 branch state
+- Preferred Engine: Either
+- Owned Paths:
+  - `prd/EXEC-CI-GEMINI-WORKFLOWS-v1.md`
+  - `.github/workflows/ci.yml`
+  - `.github/workflows/gemini-security.yml`
+
+## Overview
+Add explicit, repo-local GitHub Actions for baseline CI and Gemini Security analysis so the repository has straightforward, visible automation on PRs.
+
+## Goals
+- Add a single baseline CI workflow (`ci.yml`) that runs on PRs/pushes.
+- Add a Gemini security workflow (`gemini-security.yml`) that runs on PRs and manual dispatch.
+- Keep workflow setup simple and maintainable.
+
+## Definition of Done (DoD)
+**DoD checklist:**
+- [ ] `.github/workflows/ci.yml` exists and has lint, typecheck, and unit test jobs.
+- [ ] `.github/workflows/gemini-security.yml` exists and runs Gemini security analysis on PRs.
+- [ ] Gemini job safely skips when `GEMINI_API_KEY` is not configured.
+- [ ] Workflow files are syntactically valid YAML and committed.
+
+**Validation commands (run from repo root):**
+```bash
+set -euo pipefail
+test -f .github/workflows/ci.yml
+test -f .github/workflows/gemini-security.yml
+python3 tests/test_public_repo_boundary_audit.py
+```
+
+**Pass criteria:** files exist and local validation exits 0.
+
+## Functional Requirements
+- FR-1: CI workflow triggers on `push` to `main` and `pull_request` to `main`.
+- FR-2: CI workflow includes at least lint/typecheck/tests jobs.
+- FR-3: Gemini security workflow triggers on `pull_request` and `workflow_dispatch`.
+- FR-4: Gemini workflow uses `google-github-actions/run-gemini-cli` and security extension prompt.
+- FR-5: Missing `GEMINI_API_KEY` must not hard-fail the workflow.
+
+## Non-Goals (Out of Scope)
+- Replacing existing advanced workflows.
+- Enforcing required-check branch protections.
+- Secret provisioning automation.


### PR DESCRIPTION
## Summary
- add `.github/workflows/ci.yml` with baseline lint/typecheck/unit-test jobs
- add `.github/workflows/gemini-security.yml` for PR/workflow_dispatch Gemini security analysis
- add execution PRD: `prd/EXEC-CI-GEMINI-WORKFLOWS-v1.md`

## Validation
- `python3 tests/test_public_repo_boundary_audit.py` (passes)
- CLR verify-only: `clr-fd135d61` (APPROVE, security CLEAN)

## Notes
- Gemini workflow skips cleanly when `GEMINI_API_KEY` is missing.
