### PR TITLE
docs(prd): require cross-repo baseline review before code passes

### DIFF
--- a/prd/EPIC-PUBLICIZATION-UPSTREAM-SYNC-SIMPLIFICATION-v1.md
+++ b/prd/EPIC-PUBLICIZATION-UPSTREAM-SYNC-SIMPLIFICATION-v1.md
@@ -26,6 +26,14 @@ For any child PRD that touches code, implementation agents must run the followin
 3. Run build/tests to verify behavior.
 4. Suggest optional abstractions only if they clearly improve clarity.
 
+## Cross-Repo Review Gate (mandatory)
+For any child PRD that touches code, the implementation agent must review and compare both repositories before coding:
+- `projects/graphiti` (private/source baseline)
+- `projects/graphiti-openclaw` (public target)
+
+PR notes must include a cross-repo inventory (paths reviewed), at least 3 simplification candidates, and explicit deferrals for any unselected candidates.
+Single-file/narrow-function refactors require explicit justification for why broader owned-path opportunities were not applicable.
+
 ## Global Definition of Done (DoD)
 **Global DoD checklist:**
 - [ ] Public export boundary is codified as an allowlist and enforced by audit tooling.

--- a/prd/EXEC-PACK-ADAPTER-INTERFACE-CONTRACT-v1.md
+++ b/prd/EXEC-PACK-ADAPTER-INTERFACE-CONTRACT-v1.md
@@ -17,6 +17,13 @@
 ## Overview
 Define a stable extension interface so private/custom workflow and content packs can plug into the public core without modifying core foundation code.
 
+## Mandatory Cross-Repo Baseline Review (to prevent narrow-pass regressions)
+Before implementation, the agent must:
+1. Review corresponding paths in `projects/graphiti` (private/source baseline) and `projects/graphiti-openclaw` (public target).
+2. Produce a short cross-repo inventory in PR notes listing concrete files/directories reviewed in both repos.
+3. Identify at least 3 candidate simplifications across the owned-path surface; implement selected items or explicitly defer each candidate with rationale.
+4. If the PR touches only one file or one narrow function, include explicit justification for why broader owned-path opportunities were not applicable.
+
 ## Goals
 - Keep public core generic and clean.
 - Allow private/persona overlays to attach through explicit contracts.

--- a/prd/EXEC-PUBLIC-DOCS-RELEASE-RAILS-v1.md
+++ b/prd/EXEC-PUBLIC-DOCS-RELEASE-RAILS-v1.md
@@ -16,6 +16,13 @@
 ## Overview
 Create public-facing docs and release guardrails so external users get a clean, generalizable foundation while private/operator-specific assets remain excluded.
 
+## Mandatory Cross-Repo Baseline Review (to prevent narrow-pass regressions)
+Before implementation, the agent must:
+1. Review corresponding paths in `projects/graphiti` (private/source baseline) and `projects/graphiti-openclaw` (public target).
+2. Produce a short cross-repo inventory in PR notes listing concrete files/directories reviewed in both repos.
+3. Identify at least 3 candidate simplifications across the owned-path surface; implement selected items or explicitly defer each candidate with rationale.
+4. If the PR touches only one file or one narrow function, include explicit justification for why broader owned-path opportunities were not applicable.
+
 ## Goals
 - Make repo purpose and scope immediately clear.
 - Document security/privacy boundaries and excluded assets.

--- a/prd/EXEC-PUBLIC-FOUNDATION-BOUNDARY-CONTRACT-v1.md
+++ b/prd/EXEC-PUBLIC-FOUNDATION-BOUNDARY-CONTRACT-v1.md
@@ -16,6 +16,13 @@
 ## Overview
 Create a default-closed public-export boundary with deterministic allow/block classification and a reproducible markdown audit report.
 
+## Mandatory Cross-Repo Baseline Review (to prevent narrow-pass regressions)
+Before implementation, the agent must:
+1. Review corresponding paths in `projects/graphiti` (private/source baseline) and `projects/graphiti-openclaw` (public target).
+2. Produce a short cross-repo inventory in PR notes listing concrete files/directories reviewed in both repos.
+3. Identify at least 3 candidate simplifications across the owned-path surface; implement selected items or explicitly defer each candidate with rationale.
+4. If the PR touches only one file or one narrow function, include explicit justification for why broader owned-path opportunities were not applicable.
+
 ## Goals
 - Enforce allowlist-first public scope with denylist overrides.
 - Surface ambiguous files explicitly.

--- a/prd/EXEC-PUBLIC-HISTORY-MIGRATION-CUTOVER-v1.md
+++ b/prd/EXEC-PUBLIC-HISTORY-MIGRATION-CUTOVER-v1.md
@@ -20,6 +20,13 @@ Generate and compare two migration candidates for `yhl999/graphiti-openclaw`:
 
 Select the winner using a scorecard biased toward elegance/simplicity and safety.
 
+## Mandatory Cross-Repo Baseline Review (to prevent narrow-pass regressions)
+Before implementation, the agent must:
+1. Review corresponding paths in `projects/graphiti` (private/source baseline) and `projects/graphiti-openclaw` (public target).
+2. Produce a short cross-repo inventory in PR notes listing concrete files/directories reviewed in both repos.
+3. Identify at least 3 candidate simplifications across the owned-path surface; implement selected items or explicitly defer each candidate with rationale.
+4. If the PR touches only one file or one narrow function, include explicit justification for why broader owned-path opportunities were not applicable.
+
 ## Goals
 - Preserve useful provenance where practical.
 - Avoid leaking private files/history.

--- a/prd/EXEC-PUBLIC-REFACTOR-PASS-SIMPLIFY-v1.md
+++ b/prd/EXEC-PUBLIC-REFACTOR-PASS-SIMPLIFY-v1.md
@@ -24,6 +24,13 @@ Apply this exact flow:
 3. Run build/tests to verify behavior.
 4. Suggest optional abstractions only if they clearly improve clarity.
 
+## Mandatory Cross-Repo Baseline Review (to prevent narrow-pass regressions)
+Before implementation, the agent must:
+1. Review corresponding paths in `projects/graphiti` (private/source baseline) and `projects/graphiti-openclaw` (public target).
+2. Produce a short cross-repo inventory in PR notes listing concrete files/directories reviewed in both repos.
+3. Identify at least 3 candidate simplifications across the owned-path surface; implement selected items or explicitly defer each candidate with rationale.
+4. If the PR touches only one file or one narrow function, include explicit justification for why broader owned-path opportunities were not applicable.
+
 ## Goals
 - Reduce maintenance burden by deleting dead/duplicative pathways.
 - Simplify control flow and interfaces in foundation modules.

--- a/prd/EXEC-PUBLICIZATION-INTEGRATION-E2E-v1.md
+++ b/prd/EXEC-PUBLICIZATION-INTEGRATION-E2E-v1.md
@@ -14,6 +14,13 @@
 ## Overview
 Run full end-to-end verification of the publicization program and produce a ship/no-ship recommendation.
 
+## Mandatory Cross-Repo Baseline Review (to prevent narrow-pass regressions)
+Before implementation, the agent must:
+1. Review corresponding paths in `projects/graphiti` (private/source baseline) and `projects/graphiti-openclaw` (public target).
+2. Produce a short cross-repo inventory in PR notes listing concrete files/directories reviewed in both repos.
+3. Identify at least 3 candidate simplifications across the owned-path surface; implement selected items or explicitly defer each candidate with rationale.
+4. If the PR touches only one file or one narrow function, include explicit justification for why broader owned-path opportunities were not applicable.
+
 ## Goals
 - Prove that boundaries, migration choice, sync lane, adapter contract, and docs operate as one coherent system.
 - Verify no private leakage and no regressions in exported foundations.

--- a/prd/EXEC-STATE-MIGRATION-KIT-v1.md
+++ b/prd/EXEC-STATE-MIGRATION-KIT-v1.md
@@ -16,6 +16,13 @@
 ## Overview
 Provide a clean migration kit for runtime data so users can move Graphiti state between environments without committing private state into git.
 
+## Mandatory Cross-Repo Baseline Review (to prevent narrow-pass regressions)
+Before implementation, the agent must:
+1. Review corresponding paths in `projects/graphiti` (private/source baseline) and `projects/graphiti-openclaw` (public target).
+2. Produce a short cross-repo inventory in PR notes listing concrete files/directories reviewed in both repos.
+3. Identify at least 3 candidate simplifications across the owned-path surface; implement selected items or explicitly defer each candidate with rationale.
+4. If the PR touches only one file or one narrow function, include explicit justification for why broader owned-path opportunities were not applicable.
+
 ## Goals
 - Support deterministic export/import of required runtime state.
 - Keep migration flow simple, documented, and reversible.

--- a/prd/EXEC-UPSTREAM-SYNC-LANE-v1.md
+++ b/prd/EXEC-UPSTREAM-SYNC-LANE-v1.md
@@ -15,6 +15,13 @@
 ## Overview
 Establish a repeatable upstream sync lane for `yhl999/graphiti-openclaw` with controlled PR-based updates from `zep/graphiti`.
 
+## Mandatory Cross-Repo Baseline Review (to prevent narrow-pass regressions)
+Before implementation, the agent must:
+1. Review corresponding paths in `projects/graphiti` (private/source baseline) and `projects/graphiti-openclaw` (public target).
+2. Produce a short cross-repo inventory in PR notes listing concrete files/directories reviewed in both repos.
+3. Identify at least 3 candidate simplifications across the owned-path surface; implement selected items or explicitly defer each candidate with rationale.
+4. If the PR touches only one file or one narrow function, include explicit justification for why broader owned-path opportunities were not applicable.
+
 ## Goals
 - Keep public fork current without destabilizing local foundations.
 - Minimize merge pain via dedicated sync branches and checklists.


### PR DESCRIPTION
Adds a mandatory cross-repo review gate to the epic and all relevant execution PRDs.

## Why
A previous refactor pass landed as a narrow single-file optimization without broad comparison against `projects/graphiti` baseline. This change codifies expectations so future passes do not repeat that failure mode.

## What changed
- Added **Cross-Repo Review Gate (mandatory)** to:
  - `prd/EPIC-PUBLICIZATION-UPSTREAM-SYNC-SIMPLIFICATION-v1.md`
- Added **Mandatory Cross-Repo Baseline Review** section to relevant child PRDs:
  - `EXEC-PUBLIC-FOUNDATION-BOUNDARY-CONTRACT-v1.md`
  - `EXEC-PUBLIC-REFACTOR-PASS-SIMPLIFY-v1.md`
  - `EXEC-PUBLIC-HISTORY-MIGRATION-CUTOVER-v1.md`
  - `EXEC-UPSTREAM-SYNC-LANE-v1.md`
  - `EXEC-PACK-ADAPTER-INTERFACE-CONTRACT-v1.md`
  - `EXEC-STATE-MIGRATION-KIT-v1.md`
  - `EXEC-PUBLIC-DOCS-RELEASE-RAILS-v1.md`
  - `EXEC-PUBLICIZATION-INTEGRATION-E2E-v1.md`

## New required behavior
Before coding, agent must:
1. Review both `projects/graphiti` and `projects/graphiti-openclaw` in corresponding paths.
2. Include cross-repo inventory in PR notes.
3. Identify >=3 simplification candidates and either implement or explicitly defer each.
4. If PR is narrow/single-file, justify why broader owned-path opportunities were not applicable.
