### PR TITLE
docs: add public docs release rails (foundation-only v1)

### DIFF
--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -1,0 +1,41 @@
+# Graphiti OpenClaw Public Foundation
+
+Graphiti OpenClaw is a **public foundation fork** of Graphiti. It preserves reusable core primitives and adds a narrow publicization control layer for repeatable releases.
+
+## Scope and non-goals
+
+### Scope
+- Generalizable ingestion and memory runtime foundations.
+- Deterministic boundary governance for what can be exported.
+- Migration/sync tooling and release gates owned by this repo.
+- Minimal documentation required to keep public releases predictable.
+
+### Non-goals
+- Personal workflow packs, private examples, or content-marketing workflows.
+- Private secrets, credentials, state snapshots, or local operator artifacts.
+- Product feature development beyond publication, boundary, and release rails.
+
+## Foundation substrate vs private overlays
+
+This repo is built as a foundation layer. It is expected that private teams layer on additional packs and workflows.
+
+- **Foundation substrate (public):** `graphiti_core/**`, `mcp_server/**`, `server/**`, `tests/**`.
+- **Private overlays (do not migrate):** workflow packs, content packs, private runbooks, and private operational state.
+
+## Security and release rails
+
+Operational boundaries and release requirements live here:
+
+- `SECURITY-BOUNDARIES.md` — threat-oriented boundary model, what is blocked, and why.
+- `RELEASE-CHECKLIST.md` — mandatory pre-release gate sequence.
+- `WHAT-NOT-TO-MIGRATE.md` — explicit exclusions before public cutover.
+
+## Quick setup
+
+1. Read `SECURITY-BOUNDARIES.md` and confirm boundary policy status.
+2. Run through `RELEASE-CHECKLIST.md` before any public release operation.
+3. Keep private overlays and examples outside the foundation paths listed above.
+
+## Operating rule
+
+Everything that does not belong in a stable, reusable foundation should be treated as private layering and handled as externalized workflow/context input instead of being merged into this public core.

--- a/docs/public/RELEASE-CHECKLIST.md
+++ b/docs/public/RELEASE-CHECKLIST.md
@@ -1,0 +1,37 @@
+# Public Release Checklist
+
+Use this checklist before any public cutover, merge, or upstream sync publish.
+
+## 0) Precondition
+
+- [ ] I have compared `docs/public/README.md`, `SECURITY-BOUNDARIES.md`, and `WHAT-NOT-TO-MIGRATE.md` for consistency.
+- [ ] All intended changes are foundation-only and do not include private overlays.
+
+## 1) Boundary controls
+
+- [ ] `python3 scripts/public_repo_boundary_audit.py --manifest config/public_export_allowlist.yaml --denylist config/public_export_denylist.yaml --strict --report /tmp/boundary-audit.md`
+- [ ] `python3 scripts/public_boundary_policy_lint.py --manifest config/public_export_allowlist.yaml --denylist config/public_export_denylist.yaml`
+- [ ] Confirm no `BLOCK`/`AMBIGUOUS` findings remain outside approved remediation paths.
+
+## 2) Tooling and migration safety
+
+- [ ] `python3 scripts/delta_tool.py contracts-check -- --policy config/migration_sync_policy.json --state-manifest config/state_migration_manifest.json --contract-policy config/delta_contract_policy.json --extensions-dir extensions --strict`
+- [ ] `python3 scripts/upstream_sync_doctor.py --repo . --dry-run --check-sync-button-safety`
+- [ ] `python3 scripts/state_migration_check.py --dry-run`
+
+## 3) Runbook and docs gates
+
+- [ ] `test -s docs/public/README.md`
+- [ ] `test -s docs/public/SECURITY-BOUNDARIES.md`
+- [ ] `test -s docs/public/RELEASE-CHECKLIST.md`
+- [ ] `test -s docs/public/WHAT-NOT-TO-MIGRATE.md`
+
+## Content-marketing / public write-up gate
+
+The public write-up is deferred until all readiness criteria are true:
+
+- [ ] Ingest backlog is stable (no unresolved data-dependent blockers in current intake).
+- [ ] Content workflow and state export readiness checklist is green.
+- [ ] External-facing messaging owner explicitly signs off that no private workflow or content-pack assumptions remain.
+
+Until these gates are met: **content marketing stays deferred**.

--- a/docs/public/SECURITY-BOUNDARIES.md
+++ b/docs/public/SECURITY-BOUNDARIES.md
@@ -1,0 +1,31 @@
+# Public Security Boundaries
+
+## Boundary intent
+
+This repo is public by design, but only for generalized foundation artifacts. The boundary exists to prevent accidental migration of private execution, private data, and person-specific logic.
+
+## Threat-oriented rationale
+
+- **Data exfiltration risk**: private prompts, credentials, exports, and local state.
+- **Operational dependency risk**: private packs and scripts that break portability.
+- **Reputation and IP leakage risk**: personal workflows or private evaluation data.
+- **Maintenance burden risk**: one-off integrations that increase support cost and reduce extensibility.
+
+## Exclusion classes (must not migrate)
+
+- **Secrets and credentials**: `.env*`, API keys, certs, tokens, and signed identities.
+- **Private context and workflow packs**: packs that encode organization-specific playbooks.
+- **Personal/private data**: raw source artifacts, logs, private reports, local snapshots.
+- **Overlay-specific extensions**: adapters tied to one operator workflow.
+- **Stateful runtime artifacts**: generated state files, backfills, backups, and local persistence caches.
+- **Content strategy pack** items not intended as generic library docs.
+
+## Inclusion baseline
+
+Allowed foundations should be generally reusable with limited assumptions about environment or operator identity.
+
+If an asset is hard to describe in general terms and would require personal/process-specific onboarding, treat it as private and keep it out of public release.
+
+## Review requirements
+
+Any migration or release PR must pass boundary policy checks in `docs/public/RELEASE-CHECKLIST.md` before publication.

--- a/docs/public/WHAT-NOT-TO-MIGRATE.md
+++ b/docs/public/WHAT-NOT-TO-MIGRATE.md
@@ -1,0 +1,24 @@
+# What Not to Migrate to Public
+
+This is the explicit migration exclusion list for publicization. If unsure, do not migrate.
+
+## Block list
+
+- **Private workflow packs**: organization-specific playbooks, private runbooks, or personnel-facing procedure sets.
+- **Content packs and drafts**: `content_strategy`, writing samples, private content drafts, and marketing narratives.
+- **Private context packs**: source folders containing private context profiles and person-specific heuristics.
+- **Secrets and credentials**: `.env`, tokens, local key stores, cert bundles, private signing keys.
+- **Personal state artifacts**: local caches, backups, database dumps, exports with private identifiers.
+- **Legacy one-off adapters**: integrations bound to private providers or private data contracts.
+- **Tooling for private operators**: internal scripts and notebooks used only for one team’s workflow.
+
+## Decision rule
+
+If an artifact is required by this public repository because it changes core behavior for everyone, keep it here.
+If it exists to support one private workflow, keep it outside public release scope.
+
+## Suggested flow
+
+1. Capture private intent as a public abstraction request.
+2. Implement the abstraction as a stable interface or adapter contract.
+3. Keep concrete implementations out of the public foundation until generalized.

--- a/prd/EXEC-PUBLIC-DOCS-RELEASE-RAILS-v1.md
+++ b/prd/EXEC-PUBLIC-DOCS-RELEASE-RAILS-v1.md
@@ -8,10 +8,10 @@
 - Preferred Engine: Either
 - Owned Paths:
   - `prd/EXEC-PUBLIC-DOCS-RELEASE-RAILS-v1.md`
-  - `docs/public/README.md` (new)
-  - `docs/public/SECURITY-BOUNDARIES.md` (new)
-  - `docs/public/RELEASE-CHECKLIST.md` (new)
-  - `docs/public/WHAT-NOT-TO-MIGRATE.md` (new)
+  - `docs/public/README.md`
+  - `docs/public/SECURITY-BOUNDARIES.md`
+  - `docs/public/RELEASE-CHECKLIST.md`
+  - `docs/public/WHAT-NOT-TO-MIGRATE.md`
 
 ## Overview
 Create public-facing docs and release guardrails so external users get a clean, generalizable foundation while private/operator-specific assets remain excluded.
@@ -31,11 +31,11 @@ Before implementation, the agent must:
 
 ## Definition of Done (DoD)
 **DoD checklist:**
-- [ ] Public README explains architecture, scope, and setup for generalized use.
-- [ ] Security boundaries doc lists excluded classes and rationale.
-- [ ] "What not to migrate" doc explicitly blocks private workflow/content packs.
-- [ ] Release checklist includes mandatory pre-publish checks.
-- [ ] Docs include content-marketing gate: drafting stays deferred until ingest backlog/workflow readiness criteria are true.
+- [x] Public README explains architecture, scope, and setup for generalized use.
+- [x] Security boundaries doc lists excluded classes and rationale.
+- [x] "What not to migrate" doc explicitly blocks private workflow/content packs.
+- [x] Release checklist includes mandatory pre-publish checks.
+- [x] Docs include content-marketing gate: drafting stays deferred until ingest backlog/workflow readiness criteria are true.
 
 **Validation commands (run from repo root):**
 ```bash
@@ -54,15 +54,15 @@ rg -n "content marketing|public write-up|deferred|gate" docs/public/RELEASE-CHEC
 **Description:** As an external maintainer, I want to understand what this repo is and is not.
 
 **Acceptance Criteria:**
-- [ ] README contains a clear scope statement and non-goals.
-- [ ] README links to security boundaries and release checklist.
+- [x] README contains a clear scope statement and non-goals.
+- [x] README links to security boundaries and release checklist.
 
 ### US-002: Leak prevention through docs
 **Description:** As owner, I want docs to enforce boundaries so accidental migration of private assets is less likely.
 
 **Acceptance Criteria:**
-- [ ] Excluded asset classes are explicit and concrete.
-- [ ] Release checklist has a mandatory boundary-audit step.
+- [x] Excluded asset classes are explicit and concrete.
+- [x] Release checklist has a mandatory boundary-audit step.
 
 ## Functional Requirements
 - FR-1: README must separate "foundation substrate" from "private packs/examples".


### PR DESCRIPTION
## Summary
Implements `task-graphiti-public-docs-release-rails` from `prd/EXEC-PUBLIC-DOCS-RELEASE-RAILS-v1.md`.

This PR adds a concise public docs rail set that makes scope boundaries explicit, keeps private overlays out of public artifacts, and adds a repeatable release gate checklist with explicit content-marketing deferral criteria.

## Cross-repo baseline inventory
### Private/source baseline reviewed (`projects/graphiti`)
- `prd/EXEC-PUBLIC-DOCS-RELEASE-RAILS-v1.md`
- `prd/EXEC-PUBLIC-FOUNDATION-BOUNDARY-CONTRACT-v1.md`
- `prd/EPIC-PUBLICIZATION-UPSTREAM-SYNC-SIMPLIFICATION-v1.md`
- `docs/public/` (absent in private repo; documented as a baseline gap)

### Public target baseline reviewed (`projects/graphiti-openclaw`)
- `docs/public/BOUNDARY-CONTRACT.md`
- `docs/public/HISTORY-MIGRATION.md`
- `docs/public/MIGRATION-SYNC-TOOLKIT.md`
- `docs/public/EXTENSION-INTERFACE.md`

## Simplification loop (candidates + rationale)
1. **Selected:** consolidate public entrypoint and non-goals in a single `docs/public/README.md` instead of repeating scope statements in multiple docs.
2. **Selected:** define one explicit exclusion contract (`docs/public/WHAT-NOT-TO-MIGRATE.md`) for private packs/data to reduce ambiguity.
3. **Selected:** keep one executable release gate (`docs/public/RELEASE-CHECKLIST.md`) with concrete command checks and a mandatory content-writeup deferral gate.
4. **Deferred:** policy-as-data/owner matrix expansions for doc categories (kept out of v1 to avoid unnecessary complexity in this docs-only PRD).

## Files added/updated
- `docs/public/README.md` (new)
- `docs/public/SECURITY-BOUNDARIES.md` (new)
- `docs/public/RELEASE-CHECKLIST.md` (new)
- `docs/public/WHAT-NOT-TO-MIGRATE.md` (new)
- `prd/EXEC-PUBLIC-DOCS-RELEASE-RAILS-v1.md` (owned-path normalization + DoD tracking updates)

## Validation
Run from repo root:

```bash
set -euo pipefail
test -s docs/public/README.md
test -s docs/public/SECURITY-BOUNDARIES.md
test -s docs/public/RELEASE-CHECKLIST.md
test -s docs/public/WHAT-NOT-TO-MIGRATE.md
rg -n "content marketing|public write-up|deferred|gate" docs/public/RELEASE-CHECKLIST.md
```

Observed: all commands exit 0 and required gate language is present.

## Risk notes
- Low risk: docs-only changes under `docs/public/**` and PRD metadata.
- Main operational risk is future drift between exclusion docs/checklist; mitigated by explicit cross-links and checklist precondition step.

## Rollback
- Revert this PR commit if wording/policy framing needs adjustment.

## MUST_FIX / NITS
- MUST_FIX: none identified.
- NITS: consider adding an explicit doc ownership table in a follow-up if doc governance load increases.
