### PR TITLE
feat: Option A Phase 2 — lane filter + RRF softening + diversity

### DIFF
--- a/mcp_server/src/services/typed_retrieval_service.py
+++ b/mcp_server/src/services/typed_retrieval_service.py
@@ -268,8 +268,15 @@ def _lane_label(candidate: dict[str, Any]) -> str:
 # ── Phase 2B: Candidate Diversity Helpers ─────────────────────────────────────
 
 # Env-var overrides for tuning knobs
-_DEDUP_THRESHOLD: float = float(os.environ.get("BICAMERAL_DEDUP_THRESHOLD", "0.85"))
-_MMR_WEIGHT_DIVERSITY: float = float(os.environ.get("BICAMERAL_MMR_WEIGHT_DIVERSITY", "0.3"))
+def _parse_float_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        logger.warning("Invalid value for %s; using default %.2f", name, default)
+        return default
+
+_DEDUP_THRESHOLD: float = _parse_float_env("BICAMERAL_DEDUP_THRESHOLD", 0.85)
+_MMR_WEIGHT_DIVERSITY: float = _parse_float_env("BICAMERAL_MMR_WEIGHT_DIVERSITY", 0.3)
 
 
 def _candidate_fact_text(candidate: dict[str, Any]) -> str:

--- a/mcp_server/src/services/typed_retrieval_service.py
+++ b/mcp_server/src/services/typed_retrieval_service.py
@@ -27,6 +27,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
+import os
+import re
+import time
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -34,6 +38,8 @@ try:
     from .typed_retrieval import TypedRetrievalService
 except ImportError:  # pragma: no cover — top-level import fallback
     from services.typed_retrieval import TypedRetrievalService
+
+logger = logging.getLogger(__name__)
 
 # ── RRF tuning constants ──────────────────────────────────────────────────────
 # k=60: standard RRF constant matching experiment calibration in lane_fair_merge
@@ -45,6 +51,355 @@ _HYBRID_RRF_K: float = 60.0
 # that a weak typed match does not dominate a strong graph hit.
 _HYBRID_WEIGHT_GRAPH: float = 1.0
 _HYBRID_WEIGHT_TYPED: float = 0.85
+
+
+# ── Phase 2A: Query-Intent Lane Filter ────────────────────────────────────────
+
+# Suppression matrix: intent → list of lane labels to suppress (zero-score).
+SUPPRESSION_MATRIX: dict[str, list[str]] = {
+    "persona": ["engineering", "technical"],
+    "preference": ["engineering", "incident", "operational"],
+    "operational": [],
+    "technical": ["persona", "preference"],
+    "decision": ["persona", "preference"],
+    "engineering": [],
+    "incident": [],
+    "generic": [],
+}
+
+# Intent classification patterns: list of (compiled_regex, intent_label).
+# Order matters — first match wins.
+_INTENT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # decision — check early; "alternative … considered" can have words between
+    (re.compile(
+        r"\b(?:why\s+did\s+(?:we|you|i)|trade[\s-]?off|"
+        r"alternative(?:s)?(?:\s+\w+)*\s+considered|"
+        r"decision|decided|chose|rationale|reasoning\s+behind|"
+        r"pros?\s+(?:and|&)\s+cons?|compare|comparison|"
+        r"evaluation|evaluated|assessed|picked|selected\s+(?:over|instead))",
+        re.IGNORECASE,
+    ), "decision"),
+    # operational — before persona to avoid "schedule" false positives;
+    #   "pipeline" is qualified to avoid stealing technical queries.
+    (re.compile(
+        r"\b(?:interrupt\s+vs|batch\s+update|operational\s+(?:rule|procedure|mode)|"
+        r"communication\s+guard|guard\s+server|cron\s+(?:job|schedule|audit)|"
+        r"heartbeat|workflow|(?:deploy(?:ment)?|ci|cd|build)\s+pipeline|"
+        r"deploy(?:ment)?|rollback|runbook|"
+        r"procedure|playbook|escalat(?:e|ion)|on[\s-]?call|"
+        r"incident\s+(?:response|management|review)|post[\s-]?mortem)",
+        re.IGNORECASE,
+    ), "operational"),
+    # technical / engineering — before persona/preference to catch specific terms
+    (re.compile(
+        r"\b(?:how\s+does\s+(?:it|the|this)\s+work|architecture|spec(?:s|ification)?|"
+        r"implement(?:ation|ed)?|code|function|class|method|module|"
+        r"api|endpoint|schema|database|query|index|"
+        r"bug|fix(?:ed)?|error|exception|stack\s+trace|debug|"
+        r"performance|latency|throughput|benchmark|pipeline|"
+        r"config(?:uration)?|infrastructure|service|server|"
+        r"graph(?:iti)?|neo4j|falkordb|rrf|rerank|retrieval|"
+        r"vector|embedding|semantic|hybrid|fusion|"
+        r"typed\s+retrieval|change\s+ledger|om\s+projection|"
+        r"feature\s+flag|migration|refactor)",
+        re.IGNORECASE,
+    ), "technical"),
+    # persona — "schedule" qualified to avoid stealing operational/technical
+    (re.compile(
+        r"\b(?:favorite|favourite|prefer(?:s|red|ence)?|personality|character|"
+        r"style|habit|routine|who\s+(?:is|am)|about\s+(?:yuan|me|him|her|them)|"
+        r"schedul(?:e|ing)\s+(?:preference|default|block|habit)|"
+        r"scheduling|calendar|availability|morning|workout|"
+        r"background|family|hometown|grew\s+up|boarding\s+school|"
+        r"communication\s+(?:style|rules|preference)|"
+        r"decision\s+style|working\s+hours|meeting\s+default|buffer\s+time)",
+        re.IGNORECASE,
+    ), "persona"),
+    # preference
+    (re.compile(
+        r"\b(?:opinion\s+on|think\s+about|taste\s+in|like(?:s)?\s+(?:to|about)?|"
+        r"dislike|enjoy|love(?:s)?|hate(?:s)?|"
+        r"recommend(?:ation)?|suggestion|what\s+(?:do\s+(?:you|i)\s+think|should\s+i)|"
+        r"cuisine|restaurant|wine|food|favorite\s+(?:food|movie|book|song|color|music)|"
+        r"best\s+(?:restaurant|bar|place)|ranking|rated)",
+        re.IGNORECASE,
+    ), "preference"),
+]
+
+
+class QueryIntentClassifier:
+    """Rule-based query-intent classifier with TTL cache.
+
+    Classifies a query string into one of the intent labels used by the
+    suppression matrix.  Results are cached for 1 hour keyed on SHA-256
+    of the query to avoid redundant regex passes on repeated queries.
+    """
+
+    _CACHE_TTL_SECONDS: int = 3600  # 1 hour
+
+    def __init__(self) -> None:
+        self._cache: dict[str, tuple[str, float]] = {}
+
+    def classify(self, query: str) -> str:
+        """Classify *query* into an intent label.
+
+        Returns one of: persona, preference, decision, operational,
+        technical, engineering, incident, generic.
+        """
+        key = hashlib.sha256(query.encode()).hexdigest()
+        now = time.monotonic()
+
+        # Check cache
+        if key in self._cache:
+            intent, ts = self._cache[key]
+            if now - ts < self._CACHE_TTL_SECONDS:
+                return intent
+            # Expired — fall through to re-classify.
+
+        intent = self._classify_uncached(query)
+        self._cache[key] = (intent, now)
+        return intent
+
+    @staticmethod
+    def _classify_uncached(query: str) -> str:
+        """Run pattern matching against *query*; return intent label."""
+        for pattern, label in _INTENT_PATTERNS:
+            if pattern.search(query):
+                return label
+        return "generic"
+
+    def clear_cache(self) -> None:
+        """Clear the classification cache (useful for testing)."""
+        self._cache.clear()
+
+
+# Module-level singleton for lightweight reuse across calls.
+_query_intent_classifier = QueryIntentClassifier()
+
+
+def _lane_label(candidate: dict[str, Any]) -> str:
+    """Derive a lane label from candidate metadata.
+
+    Inspects ``_source``, entity type, tags, bucket, and object type to
+    return one of: persona, preference, operational, technical, decision,
+    engineering, incident, generic.
+    """
+    source = str(candidate.get("_source", "") or "").lower()
+
+    # ── Typed candidates (from ChangeLedger) ──────────────────────────────
+    if source in ("typed_state", "typed_procedure"):
+        original = candidate.get("_original", {}) or {}
+        obj_type = str(original.get("object_type", "") or "").lower()
+        bucket = str(original.get("bucket", "") or "").lower()
+        subject = str(original.get("subject", "") or "").lower()
+        tags = [str(t).lower() for t in (original.get("tags", []) or [])]
+
+        # Explicit bucket match
+        if bucket in ("persona",):
+            return "persona"
+        if bucket in ("preference", "preferences"):
+            return "preference"
+        if bucket in ("operational",):
+            return "operational"
+        if bucket in ("decision", "decisions"):
+            return "decision"
+
+        # Object-type / tag heuristics
+        if obj_type in ("persona", "identity"):
+            return "persona"
+        if obj_type in ("preference",):
+            return "preference"
+        if obj_type in ("decision", "decision_framework"):
+            return "decision"
+        if obj_type in ("procedure",) or "decision_framework" in tags:
+            return "decision"
+        if any(t in tags for t in ("engineering", "ops", "architecture", "technical")):
+            return "engineering"
+
+        # Subject-based heuristics
+        if any(kw in subject for kw in ("favorite", "preference", "taste", "opinion")):
+            return "preference"
+        if any(kw in subject for kw in ("schedule", "calendar", "routine", "habit")):
+            return "persona"
+
+        return "generic"
+
+    # ── Graph candidates ──────────────────────────────────────────────────
+    if source == "graph":
+        entity_type = str(candidate.get("entity_type", "") or "").lower()
+        name = str(candidate.get("name", "") or "").lower()
+        fact = str(candidate.get("fact", "") or "").lower()
+        tags = [str(t).lower() for t in (candidate.get("tags", []) or [])]
+        group_id = str(candidate.get("group_id", "") or "").lower()
+
+        # Incident detection
+        if entity_type == "incident" or "incident" in tags:
+            return "incident"
+
+        # Engineering / technical signals
+        engineering_keywords = (
+            "feature flag", "migration", "refactor", "bug", "fix",
+            "scanner", "runtime", "version", "config", "deploy",
+            "pipeline", "ci/cd", "test", "spec",
+        )
+        if any(kw in name or kw in fact for kw in engineering_keywords):
+            return "engineering"
+        if any(t in ("engineering", "ops", "architecture", "technical") for t in tags):
+            return "engineering"
+
+        # Persona / preference signals from graph
+        persona_keywords = (
+            "favorite", "preference", "schedule", "routine",
+            "personality", "background", "family",
+        )
+        if any(kw in name or kw in fact for kw in persona_keywords):
+            return "persona"
+
+        # Decision signals
+        if "decision" in entity_type or "decision" in name or "trade-off" in fact:
+            return "decision"
+
+        return "generic"
+
+    # Fallback
+    return "generic"
+
+
+# ── Phase 2B: Candidate Diversity Helpers ─────────────────────────────────────
+
+# Env-var overrides for tuning knobs
+_DEDUP_THRESHOLD: float = float(os.environ.get("BICAMERAL_DEDUP_THRESHOLD", "0.85"))
+_MMR_WEIGHT_DIVERSITY: float = float(os.environ.get("BICAMERAL_MMR_WEIGHT_DIVERSITY", "0.3"))
+
+
+def _candidate_fact_text(candidate: dict[str, Any]) -> str:
+    """Extract canonical text from a candidate for similarity comparison."""
+    parts: list[str] = []
+
+    # Primary: fact text
+    fact = str(candidate.get("fact", "") or "")
+    if fact:
+        parts.append(fact)
+
+    # Secondary: name
+    name = str(candidate.get("name", "") or "")
+    if name and name != fact:
+        parts.append(name)
+
+    # For typed items, pull subject/predicate/value from _original
+    original = candidate.get("_original", {}) or {}
+    for key in ("subject", "predicate", "value"):
+        v = str(original.get(key, "") or "")
+        if v and v not in parts:
+            parts.append(v)
+
+    return " ".join(parts).strip() or str(candidate.get("uuid", ""))
+
+
+def _tokenize(text: str) -> set[str]:
+    """Simple whitespace + lowercased tokenizer for Jaccard similarity."""
+    return set(re.findall(r"\w+", text.lower()))
+
+
+def _text_similarity(a: str, b: str) -> float:
+    """Jaccard token overlap similarity (0.0–1.0)."""
+    tokens_a = _tokenize(a)
+    tokens_b = _tokenize(b)
+    if not tokens_a or not tokens_b:
+        return 0.0
+    intersection = tokens_a & tokens_b
+    union = tokens_a | tokens_b
+    return len(intersection) / len(union) if union else 0.0
+
+
+def _dedup_candidates(
+    candidates: list[dict[str, Any]],
+    threshold: float | None = None,
+) -> list[dict[str, Any]]:
+    """Remove near-duplicate candidates.
+
+    Keeps the highest-scoring variant (assumes *candidates* is sorted by
+    descending ``_hybrid_score`` already).
+
+    Args:
+        candidates: Score-sorted candidate list.
+        threshold: Jaccard similarity threshold (0.0–1.0).  Defaults to
+            ``_DEDUP_THRESHOLD`` (env-overridable).
+
+    Returns:
+        De-duplicated list preserving original order.
+    """
+    if threshold is None:
+        threshold = _DEDUP_THRESHOLD
+
+    kept: list[dict[str, Any]] = []
+    for candidate in candidates:
+        fact_text = _candidate_fact_text(candidate)
+        is_dup = False
+        for kept_cand in kept:
+            kept_text = _candidate_fact_text(kept_cand)
+            if _text_similarity(fact_text, kept_text) >= threshold:
+                is_dup = True
+                break
+        if not is_dup:
+            kept.append(candidate)
+    return kept
+
+
+def _apply_mmr_diversity(
+    candidates: list[dict[str, Any]],
+    mmr_weight: float | None = None,
+    max_items: int = 10,
+) -> list[dict[str, Any]]:
+    """Re-rank candidates using Maximal Marginal Relevance.
+
+    Balances relevance (``_hybrid_score``) with diversity (Jaccard distance
+    from already-selected candidates).
+
+    Args:
+        candidates: Input candidate list (post-dedup).
+        mmr_weight: Diversity weight λ (0 = pure relevance, 1 = pure
+            diversity).  Defaults to ``_MMR_WEIGHT_DIVERSITY``.
+        max_items: Maximum items to select.
+
+    Returns:
+        MMR-reranked list, length ≤ min(len(candidates), max_items).
+    """
+    if mmr_weight is None:
+        mmr_weight = _MMR_WEIGHT_DIVERSITY
+
+    if not candidates:
+        return []
+
+    selected: list[dict[str, Any]] = []
+    remaining = list(candidates)
+
+    while remaining and len(selected) < max_items:
+        best_idx = 0
+        best_mmr = float("-inf")
+
+        for i, cand in enumerate(remaining):
+            relevance = cand.get("_hybrid_score", 0.0)
+
+            # Diversity penalty: max similarity to any already-selected
+            if selected:
+                cand_text = _candidate_fact_text(cand)
+                max_sim = max(
+                    _text_similarity(cand_text, _candidate_fact_text(s))
+                    for s in selected
+                )
+            else:
+                max_sim = 0.0
+
+            mmr_score = (1.0 - mmr_weight) * relevance - mmr_weight * max_sim
+
+            if mmr_score > best_mmr:
+                best_mmr = mmr_score
+                best_idx = i
+
+        selected.append(remaining.pop(best_idx))
+
+    return selected
 
 
 # ── Key helpers for deduplication ────────────────────────────────────────────
@@ -130,12 +485,22 @@ def rrf_merge_hybrid(
     rrf_k: float = _HYBRID_RRF_K,
     weight_graph: float = _HYBRID_WEIGHT_GRAPH,
     weight_typed: float = _HYBRID_WEIGHT_TYPED,
+    query_intent: str | None = None,
+    apply_diversity: bool = True,
 ) -> list[dict[str, Any]]:
     """Reciprocal Rank Fusion over graph facts + typed state/procedure candidates.
 
     Each source is ranked independently and weighted. Items that appear in
     multiple sources accumulate their RRF scores. The merged list is returned
     in score-descending order, capped at ``max_facts``.
+
+    Phase 2A: When *query_intent* is provided, candidates whose lane label
+    is in the suppression matrix for that intent are zero-scored before
+    final ranking.
+
+    Phase 2B: After scoring and suppression, near-duplicate candidates are
+    removed and MMR diversity re-ranking is applied (when *apply_diversity*
+    is True).
 
     Args:
         graph_facts: Ranked list of graph-edge facts (index 0 = best).
@@ -145,6 +510,11 @@ def rrf_merge_hybrid(
         rrf_k: RRF smoothing constant.
         weight_graph: Multiplicative weight for graph-edge source.
         weight_typed: Multiplicative weight for typed-ledger source.
+        query_intent: Optional intent label from QueryIntentClassifier.
+            When provided, candidates in suppressed lanes are zero-scored.
+        apply_diversity: When True (default), apply dedup + MMR diversity
+            after RRF merge.  Set to False when an LLM reranker will run
+            downstream.
 
     Returns:
         Merged list of hybrid-entry dicts, annotated with ``_source`` and
@@ -177,13 +547,37 @@ def rrf_merge_hybrid(
         if key not in registry:
             registry[key] = _typed_to_hybrid_entry(item, source_label="typed_procedure")
 
+    # ── Phase 2A: Lane suppression ────────────────────────────────────────
+    if query_intent:
+        suppressed_lanes = SUPPRESSION_MATRIX.get(query_intent, [])
+        if suppressed_lanes:
+            for key in list(scores.keys()):
+                candidate = registry.get(key)
+                if candidate is not None:
+                    lane = _lane_label(candidate)
+                    if lane in suppressed_lanes:
+                        scores[key] = 0.0
+
     # Annotate with final RRF scores.
     for key, score in scores.items():
         if key in registry:
             registry[key]["_hybrid_score"] = round(score, 6)
 
     ordered_keys = sorted(scores, key=lambda k: (-scores[k], k))
-    return [registry[k] for k in ordered_keys[:max_facts]]
+    merged = [registry[k] for k in ordered_keys]
+
+    # ── Phase 2B: Dedup + MMR diversity ───────────────────────────────────
+    if apply_diversity and merged:
+        try:
+            merged = _dedup_candidates(merged)
+        except Exception:
+            logger.warning("Candidate dedup failed; returning undeduped pool", exc_info=True)
+        try:
+            merged = _apply_mmr_diversity(merged, max_items=max_facts)
+        except Exception:
+            logger.warning("MMR diversity failed; returning pool without MMR", exc_info=True)
+
+    return merged[:max_facts]
 
 
 # ── Service class ─────────────────────────────────────────────────────────────
@@ -266,6 +660,8 @@ class HybridRetrievalService:
         graph_facts: list[dict[str, Any]],
         typed_results: dict[str, Any],
         max_facts: int,
+        query: str | None = None,
+        apply_diversity: bool = True,
     ) -> list[dict[str, Any]]:
         """Merge graph-recall facts with typed state/procedure candidates via RRF.
 
@@ -273,17 +669,30 @@ class HybridRetrievalService:
             graph_facts: Ranked graph-edge facts from the graph recall path.
             typed_results: Result dict from :meth:`get_typed_candidates`.
             max_facts: Maximum items in the returned merged list.
+            query: Original query string.  When provided, the query-intent
+                classifier runs and passes the intent to the RRF merge for
+                lane suppression.
+            apply_diversity: When True (default), dedup + MMR diversity is
+                applied.  Set to False when an LLM reranker runs downstream.
 
         Returns:
             RRF-merged list of hybrid entries, score-descending.
         """
         state_items: list[dict[str, Any]] = typed_results.get("state", []) or []
         procedure_items: list[dict[str, Any]] = typed_results.get("procedures", []) or []
+
+        # Phase 2A: classify query intent for lane suppression
+        intent: str | None = None
+        if query:
+            intent = _query_intent_classifier.classify(query)
+
         return rrf_merge_hybrid(
             graph_facts=graph_facts,
             typed_state=state_items,
             typed_procedures=procedure_items,
             max_facts=max_facts,
+            query_intent=intent,
+            apply_diversity=apply_diversity,
         )
 
 

--- a/mcp_server/tests/test_hybrid_retrieval_diversity.py
+++ b/mcp_server/tests/test_hybrid_retrieval_diversity.py
@@ -1,0 +1,462 @@
+"""
+Tests for Phase 2B: RRF Softening + Candidate Diversity.
+
+Covers:
+- _HYBRID_RRF_K value (should be 60.0)
+- _candidate_fact_text extraction
+- _text_similarity (Jaccard token overlap)
+- _dedup_candidates (identical, similar, dissimilar)
+- _apply_mmr_diversity (relevance-only, diversity-only, balanced)
+- rrf_merge_hybrid with diversity pipeline
+- No regression, no duplicates in top-10
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# Ensure the MCP server source is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from services.typed_retrieval_service import (
+    _HYBRID_RRF_K,
+    _candidate_fact_text,
+    _text_similarity,
+    _tokenize,
+    _dedup_candidates,
+    _apply_mmr_diversity,
+    rrf_merge_hybrid,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_candidate(
+    fact: str,
+    score: float = 0.1,
+    *,
+    name: str = "",
+    uuid: str | None = None,
+    source: str = "graph",
+) -> dict[str, Any]:
+    """Build a synthetic candidate with a hybrid score."""
+    return {
+        "uuid": uuid or hashlib.md5(fact.encode(), usedforsecurity=False).hexdigest()[:8],
+        "name": name or fact[:30],
+        "fact": fact,
+        "_source": source,
+        "_hybrid_score": score,
+        "_original": {},
+    }
+
+
+def _make_graph_fact(
+    name: str,
+    fact: str = "",
+    *,
+    uuid: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "uuid": uuid or hashlib.md5(name.encode(), usedforsecurity=False).hexdigest()[:8],
+        "name": name,
+        "fact": fact or f"Fact about {name}",
+        "_source": "graph",
+    }
+
+
+def _make_typed_state(
+    subject: str,
+    predicate: str = "is",
+    value: str = "something",
+    *,
+    object_id: str | None = None,
+    bucket: str = "",
+) -> dict[str, Any]:
+    return {
+        "object_id": object_id or hashlib.md5(subject.encode(), usedforsecurity=False).hexdigest()[:8],
+        "subject": subject,
+        "predicate": predicate,
+        "value": value,
+        "bucket": bucket,
+    }
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 1: RRF Constant
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestRRFConstant:
+    """Verify the RRF smoothing constant is set to 60.0."""
+
+    def test_rrf_k_is_60(self):
+        assert _HYBRID_RRF_K == 60.0
+
+    def test_rrf_k_softens_position_bias(self):
+        """With k=60, rank 1 vs rank 2 difference should be <5%."""
+        score_rank1 = 1.0 / (60.0 + 1)
+        score_rank2 = 1.0 / (60.0 + 2)
+        pct_diff = (score_rank1 - score_rank2) / score_rank1
+        assert pct_diff < 0.05  # less than 5% difference
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 2: _candidate_fact_text
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestCandidateFactText:
+    """Tests for _candidate_fact_text helper."""
+
+    def test_extracts_fact(self):
+        c = _make_candidate("This is a test fact about sessions")
+        text = _candidate_fact_text(c)
+        assert "This is a test fact about sessions" in text
+
+    def test_includes_name(self):
+        c = _make_candidate("some fact", name="important name")
+        text = _candidate_fact_text(c)
+        assert "important name" in text
+
+    def test_includes_original_fields(self):
+        c = _make_candidate("fact")
+        c["_original"] = {
+            "subject": "Yuan",
+            "predicate": "likes",
+            "value": "sushi",
+        }
+        text = _candidate_fact_text(c)
+        assert "Yuan" in text
+        assert "likes" in text
+        assert "sushi" in text
+
+    def test_empty_candidate_returns_uuid(self):
+        c = {"uuid": "abc123", "fact": "", "name": "", "_original": {}}
+        text = _candidate_fact_text(c)
+        assert text == "abc123"
+
+    def test_deduplicates_name_and_fact(self):
+        """If name == fact, don't repeat."""
+        c = _make_candidate("same text", name="same text")
+        text = _candidate_fact_text(c)
+        # "same text" should appear only once
+        assert text.count("same text") == 1
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 3: _text_similarity (Jaccard)
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestTextSimilarity:
+    """Tests for Jaccard token-overlap similarity."""
+
+    def test_identical_strings(self):
+        assert _text_similarity("hello world", "hello world") == 1.0
+
+    def test_completely_different(self):
+        sim = _text_similarity("alpha beta gamma", "delta epsilon zeta")
+        assert sim == 0.0
+
+    def test_partial_overlap(self):
+        sim = _text_similarity("hello world foo", "hello world bar")
+        # Overlap: {hello, world}, Union: {hello, world, foo, bar}
+        assert abs(sim - 0.5) < 0.01
+
+    def test_empty_strings(self):
+        assert _text_similarity("", "") == 0.0
+        assert _text_similarity("hello", "") == 0.0
+        assert _text_similarity("", "hello") == 0.0
+
+    def test_case_insensitive(self):
+        assert _text_similarity("Hello World", "hello world") == 1.0
+
+    def test_near_duplicate_high_similarity(self):
+        a = "Sessions Main experiment v7 shows memory architecture"
+        b = "Sessions Main experiment v7 variant A shows memory architecture"
+        sim = _text_similarity(a, b)
+        assert sim > 0.75
+
+    def test_tokenize_basic(self):
+        tokens = _tokenize("Hello, World! 123")
+        assert tokens == {"hello", "world", "123"}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 4: _dedup_candidates
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestDedupCandidates:
+    """Tests for near-duplicate removal."""
+
+    def test_identical_candidates_dedup_to_one(self):
+        c1 = _make_candidate("Exact same fact about memory architecture", score=0.9, uuid="a1")
+        c2 = _make_candidate("Exact same fact about memory architecture", score=0.8, uuid="a2")
+        result = _dedup_candidates([c1, c2], threshold=0.85)
+        assert len(result) == 1
+        assert result[0]["_hybrid_score"] == 0.9  # keeps highest-scored
+
+    def test_similar_candidates_deduped(self):
+        c1 = _make_candidate(
+            "Sessions Main experiment v7 memory architecture",
+            score=0.88, uuid="b1",
+            name="Sessions Main experiment v7 memory architecture",
+        )
+        c2 = _make_candidate(
+            "Sessions Main experiment v7 memory architecture results",
+            score=0.85, uuid="b2",
+            name="Sessions Main experiment v7 memory architecture results",
+        )
+        # Jaccard overlap between these is high (>0.65)
+        result = _dedup_candidates([c1, c2], threshold=0.65)
+        assert len(result) == 1
+
+    def test_dissimilar_candidates_kept(self):
+        c1 = _make_candidate("Yuan likes Japanese food for dinner", score=0.9, uuid="c1")
+        c2 = _make_candidate("The RRF merge architecture uses k=60", score=0.8, uuid="c2")
+        c3 = _make_candidate("Deploy pipeline runs every 30 minutes", score=0.7, uuid="c3")
+        result = _dedup_candidates([c1, c2, c3], threshold=0.85)
+        assert len(result) == 3
+
+    def test_preserves_order(self):
+        """Highest-scored first, then next unique, etc."""
+        candidates = [
+            _make_candidate("Alpha fact unique content", score=0.9, uuid="d1"),
+            _make_candidate("Beta fact different content", score=0.8, uuid="d2"),
+            _make_candidate("Gamma fact another topic", score=0.7, uuid="d3"),
+        ]
+        result = _dedup_candidates(candidates, threshold=0.85)
+        scores = [r["_hybrid_score"] for r in result]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_empty_input(self):
+        assert _dedup_candidates([], threshold=0.85) == []
+
+    def test_single_candidate(self):
+        c = _make_candidate("only one", score=0.5)
+        result = _dedup_candidates([c], threshold=0.85)
+        assert len(result) == 1
+
+    def test_three_variants_dedup_to_one(self):
+        """Three near-identical variants → keep highest only."""
+        base = "Sessions Main experiment v7 shows AI memory"
+        c1 = _make_candidate(base, score=0.88, uuid="e1")
+        c2 = _make_candidate(base + " architecture", score=0.85, uuid="e2")
+        c3 = _make_candidate(base + " architecture results", score=0.82, uuid="e3")
+        result = _dedup_candidates([c1, c2, c3], threshold=0.70)
+        assert len(result) == 1
+        assert result[0]["_hybrid_score"] == 0.88
+
+    def test_threshold_zero_keeps_all(self):
+        """threshold=0 → no dedup (nothing reaches threshold)."""
+        c1 = _make_candidate("fact A", score=0.9, uuid="f1")
+        c2 = _make_candidate("fact A", score=0.8, uuid="f2")
+        # Jaccard of identical text = 1.0 > 0.0, so they will be deduped
+        # ... actually threshold=0 means everything ≥ 0 is a dup. Let's use 1.01.
+        result = _dedup_candidates([c1, c2], threshold=1.01)
+        assert len(result) == 2  # nothing reaches threshold of 1.01
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 5: _apply_mmr_diversity
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestApplyMmrDiversity:
+    """Tests for MMR re-ranking."""
+
+    def _diverse_candidates(self) -> list[dict[str, Any]]:
+        """Build a set of candidates with varying similarity."""
+        return [
+            _make_candidate("Memory architecture uses graph and typed retrieval", score=0.10, uuid="m1"),
+            _make_candidate("Memory architecture uses graph typed retrieval system", score=0.09, uuid="m2"),
+            _make_candidate("Yuan prefers Japanese cuisine for dinner", score=0.08, uuid="m3"),
+            _make_candidate("Deploy pipeline runs every thirty minutes on cron", score=0.07, uuid="m4"),
+            _make_candidate("RRF merge with k=60 softens position bias", score=0.06, uuid="m5"),
+        ]
+
+    def test_relevance_only(self):
+        """mmr_weight=0 → pure relevance, same order as input."""
+        candidates = self._diverse_candidates()
+        result = _apply_mmr_diversity(candidates, mmr_weight=0.0, max_items=5)
+        scores = [r["_hybrid_score"] for r in result]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_diversity_promotes_dissimilar(self):
+        """mmr_weight=1.0 → max diversity; similar items should be separated."""
+        candidates = self._diverse_candidates()
+        result = _apply_mmr_diversity(candidates, mmr_weight=1.0, max_items=5)
+        # m1 and m2 are very similar — with full diversity weight,
+        # m2 should not be selected right after m1
+        uuids = [r.get("uuid") for r in result]
+        if "m1" in uuids and "m2" in uuids:
+            idx1 = uuids.index("m1")
+            idx2 = uuids.index("m2")
+            assert abs(idx1 - idx2) > 1  # not adjacent
+
+    def test_balanced_mmr(self):
+        """mmr_weight=0.3 → balanced, all items present."""
+        candidates = self._diverse_candidates()
+        result = _apply_mmr_diversity(candidates, mmr_weight=0.3, max_items=5)
+        assert len(result) == 5
+
+    def test_max_items_cap(self):
+        candidates = self._diverse_candidates()
+        result = _apply_mmr_diversity(candidates, mmr_weight=0.3, max_items=3)
+        assert len(result) == 3
+
+    def test_empty_input(self):
+        assert _apply_mmr_diversity([], mmr_weight=0.3) == []
+
+    def test_single_candidate(self):
+        c = _make_candidate("only one", score=0.5)
+        result = _apply_mmr_diversity([c], mmr_weight=0.3, max_items=5)
+        assert len(result) == 1
+
+    def test_first_selected_is_highest_score(self):
+        """MMR always picks the highest-relevance item first."""
+        candidates = self._diverse_candidates()
+        result = _apply_mmr_diversity(candidates, mmr_weight=0.3, max_items=5)
+        assert result[0]["_hybrid_score"] == max(c["_hybrid_score"] for c in candidates)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 6: Integration — rrf_merge_hybrid with diversity
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestRrfMergeWithDiversity:
+    """Integration tests for the full RRF + dedup + MMR pipeline."""
+
+    def test_no_duplicates_in_top_10(self):
+        """After dedup+MMR, no near-duplicates should appear in top-10."""
+        # Create graph facts with duplicates
+        graph_facts = [
+            _make_graph_fact("experiment v7 memory architecture", uuid="g1"),
+            _make_graph_fact("experiment v7 memory architecture variant", uuid="g2"),
+            _make_graph_fact("experiment v7 memory architecture results", uuid="g3"),
+            _make_graph_fact("Yuan favorite cuisine Japanese", uuid="g4"),
+            _make_graph_fact("deploy pipeline cron schedule", uuid="g5"),
+            _make_graph_fact("RRF merge fusion scoring", uuid="g6"),
+        ]
+        typed_state = [
+            _make_typed_state("scheduling preference", bucket="persona"),
+            _make_typed_state("wine selection taste", bucket="preference"),
+        ]
+        results = rrf_merge_hybrid(
+            graph_facts=graph_facts,
+            typed_state=typed_state,
+            typed_procedures=[],
+            max_facts=10,
+            apply_diversity=True,
+        )
+        # Check no two items in results have similarity ≥ 0.85
+        for i, a in enumerate(results):
+            for j, b in enumerate(results):
+                if i >= j:
+                    continue
+                sim = _text_similarity(
+                    _candidate_fact_text(a), _candidate_fact_text(b)
+                )
+                assert sim < 0.85, (
+                    f"Near-duplicates in top-10: items {i} and {j} "
+                    f"have similarity {sim:.2f}"
+                )
+
+    def test_diversity_disabled_no_dedup(self):
+        """apply_diversity=False → raw RRF, no dedup/MMR."""
+        graph_facts = [
+            _make_graph_fact("same fact about memory", uuid="h1"),
+            _make_graph_fact("same fact about memory", uuid="h2"),
+        ]
+        results = rrf_merge_hybrid(
+            graph_facts=graph_facts,
+            typed_state=[],
+            typed_procedures=[],
+            max_facts=10,
+            apply_diversity=False,
+        )
+        # Both should be present (no dedup)
+        assert len(results) == 2
+
+    def test_no_regression_basic_merge(self):
+        """Basic merge without intent or diversity still works."""
+        graph_facts = [
+            _make_graph_fact("fact A", uuid="r1"),
+            _make_graph_fact("fact B", uuid="r2"),
+        ]
+        typed_state = [
+            _make_typed_state("state C", object_id="r3"),
+        ]
+        results = rrf_merge_hybrid(
+            graph_facts=graph_facts,
+            typed_state=typed_state,
+            typed_procedures=[],
+            max_facts=10,
+            query_intent=None,
+            apply_diversity=False,
+        )
+        assert len(results) == 3
+        assert all(r["_hybrid_score"] > 0 for r in results)
+        # Score-descending order
+        scores = [r["_hybrid_score"] for r in results]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_max_facts_respected_with_diversity(self):
+        graph_facts = [_make_graph_fact(f"unique fact {i}", uuid=f"u{i}") for i in range(15)]
+        results = rrf_merge_hybrid(
+            graph_facts=graph_facts,
+            typed_state=[],
+            typed_procedures=[],
+            max_facts=10,
+            apply_diversity=True,
+        )
+        assert len(results) <= 10
+
+    def test_empty_inputs(self):
+        results = rrf_merge_hybrid(
+            graph_facts=[],
+            typed_state=[],
+            typed_procedures=[],
+            max_facts=10,
+            apply_diversity=True,
+        )
+        assert results == []
+
+    def test_max_facts_zero(self):
+        results = rrf_merge_hybrid(
+            graph_facts=[_make_graph_fact("test")],
+            typed_state=[],
+            typed_procedures=[],
+            max_facts=0,
+        )
+        assert results == []
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 7: Env var overrides
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestEnvVarOverrides:
+    """Test that env var overrides are respected."""
+
+    def test_dedup_threshold_env(self):
+        """BICAMERAL_DEDUP_THRESHOLD should override default."""
+        with patch.dict(os.environ, {"BICAMERAL_DEDUP_THRESHOLD": "0.50"}):
+            # Re-import to pick up new env value
+            import importlib
+            import services.typed_retrieval_service as mod
+            importlib.reload(mod)
+            assert mod._DEDUP_THRESHOLD == 0.50
+            # Restore
+            importlib.reload(mod)
+
+    def test_mmr_weight_env(self):
+        """BICAMERAL_MMR_WEIGHT_DIVERSITY should override default."""
+        with patch.dict(os.environ, {"BICAMERAL_MMR_WEIGHT_DIVERSITY": "0.70"}):
+            import importlib
+            import services.typed_retrieval_service as mod
+            importlib.reload(mod)
+            assert mod._MMR_WEIGHT_DIVERSITY == 0.70
+            # Restore
+            importlib.reload(mod)

--- a/mcp_server/tests/test_hybrid_retrieval_diversity.py
+++ b/mcp_server/tests/test_hybrid_retrieval_diversity.py
@@ -249,12 +249,10 @@ class TestDedupCandidates:
         assert len(result) == 1
         assert result[0]["_hybrid_score"] == 0.88
 
-    def test_threshold_zero_keeps_all(self):
-        """threshold=0 → no dedup (nothing reaches threshold)."""
+    def test_threshold_above_one_keeps_all(self):
+        """threshold > 1.0 → nothing reaches it, all candidates kept."""
         c1 = _make_candidate("fact A", score=0.9, uuid="f1")
         c2 = _make_candidate("fact A", score=0.8, uuid="f2")
-        # Jaccard of identical text = 1.0 > 0.0, so they will be deduped
-        # ... actually threshold=0 means everything ≥ 0 is a dup. Let's use 1.01.
         result = _dedup_candidates([c1, c2], threshold=1.01)
         assert len(result) == 2  # nothing reaches threshold of 1.01
 

--- a/mcp_server/tests/test_hybrid_retrieval_lane_filter.py
+++ b/mcp_server/tests/test_hybrid_retrieval_lane_filter.py
@@ -1,0 +1,540 @@
+"""
+Tests for Phase 2A: Query-Intent Lane Filter.
+
+Covers:
+- QueryIntentClassifier: caching, intent classification on 20+ queries, fallback
+- _lane_label: graph + typed candidate lane assignment
+- Suppression logic in rrf_merge_hybrid
+- No-regression without intent param
+"""
+from __future__ import annotations
+
+import hashlib
+import sys
+import os
+import time
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# Ensure the MCP server source is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from services.typed_retrieval_service import (
+    QueryIntentClassifier,
+    SUPPRESSION_MATRIX,
+    _lane_label,
+    rrf_merge_hybrid,
+    HybridRetrievalService,
+    _query_intent_classifier,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_graph_fact(
+    name: str,
+    fact: str = "",
+    *,
+    uuid: str | None = None,
+    entity_type: str = "",
+    tags: list[str] | None = None,
+    group_id: str = "",
+) -> dict[str, Any]:
+    """Build a synthetic graph-edge fact."""
+    return {
+        "uuid": uuid or hashlib.md5(name.encode(), usedforsecurity=False).hexdigest()[:8],
+        "name": name,
+        "fact": fact or f"Fact about {name}",
+        "_source": "graph",
+        "entity_type": entity_type,
+        "tags": tags or [],
+        "group_id": group_id,
+    }
+
+
+def _make_typed_state(
+    subject: str,
+    predicate: str = "is",
+    value: str = "something",
+    *,
+    object_id: str | None = None,
+    bucket: str = "",
+    object_type: str = "",
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a synthetic typed state item (ChangeLedger format)."""
+    return {
+        "object_id": object_id or hashlib.md5(subject.encode(), usedforsecurity=False).hexdigest()[:8],
+        "subject": subject,
+        "predicate": predicate,
+        "value": value,
+        "bucket": bucket,
+        "object_type": object_type,
+        "tags": tags or [],
+    }
+
+
+def _make_typed_procedure(
+    name: str,
+    trigger: str = "manual",
+    *,
+    object_id: str | None = None,
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a synthetic typed procedure item."""
+    return {
+        "object_id": object_id or hashlib.md5(name.encode(), usedforsecurity=False).hexdigest()[:8],
+        "name": name,
+        "trigger": trigger,
+        "object_type": "procedure",
+        "tags": tags or [],
+    }
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 1: QueryIntentClassifier
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestQueryIntentClassifier:
+    """Unit tests for QueryIntentClassifier."""
+
+    def setup_method(self):
+        self.classifier = QueryIntentClassifier()
+
+    # ── Caching ───────────────────────────────────────────────────────────
+
+    def test_cache_hit_returns_same_result(self):
+        """Same query → same cached result without re-classification."""
+        result1 = self.classifier.classify("What are Yuan's favorite cuisines?")
+        result2 = self.classifier.classify("What are Yuan's favorite cuisines?")
+        assert result1 == result2
+
+    def test_cache_stores_entry(self):
+        """Verify the internal cache is populated."""
+        self.classifier.classify("test query alpha")
+        key = hashlib.sha256(b"test query alpha").hexdigest()
+        assert key in self.classifier._cache
+
+    def test_cache_clear(self):
+        """clear_cache() empties internal state."""
+        self.classifier.classify("some query")
+        assert len(self.classifier._cache) > 0
+        self.classifier.clear_cache()
+        assert len(self.classifier._cache) == 0
+
+    def test_cache_ttl_expiry(self):
+        """Expired entries are re-classified."""
+        self.classifier.classify("ttl test query")
+        key = hashlib.sha256(b"ttl test query").hexdigest()
+        # Manually expire the entry
+        intent, _ = self.classifier._cache[key]
+        self.classifier._cache[key] = (intent, time.monotonic() - 7200)
+        # Re-classify — should go through uncached path
+        result = self.classifier.classify("ttl test query")
+        _, ts = self.classifier._cache[key]
+        assert time.monotonic() - ts < 5  # freshly cached
+
+    # ── Intent classification (20+ example queries) ───────────────────────
+
+    @pytest.mark.parametrize("query,expected", [
+        # persona
+        ("What are Yuan's favorite cuisines?", "persona"),
+        ("Tell me about Yuan's scheduling preference", "persona"),
+        ("What is his communication style?", "persona"),
+        ("What are the meeting defaults?", "persona"),
+        ("Who is Yuan?", "persona"),
+        ("What is Yuan's background?", "persona"),
+        ("What are his working hours?", "persona"),
+        # preference
+        ("What's his opinion on React vs Vue?", "preference"),
+        ("Does Yuan like sushi?", "preference"),
+        ("What's the best restaurant for dinner?", "preference"),
+        ("Any wine recommendation for tonight?", "preference"),
+        ("What cuisine does Yuan enjoy most?", "preference"),
+        # decision
+        ("Why did we pick FalkorDB over Neo4j?", "decision"),
+        ("What were the trade-offs for the hybrid approach?", "decision"),
+        ("What alternative was considered for RRF?", "decision"),
+        ("Rationale behind the k=60 constant?", "decision"),
+        # operational
+        ("How does the interrupt vs batch update work?", "operational"),
+        ("What's the cron schedule for audits?", "operational"),
+        ("Describe the heartbeat workflow", "operational"),
+        ("Show me the deployment procedure", "operational"),
+        # technical
+        ("How does the RRF merge function work?", "technical"),
+        ("What is the hybrid retrieval architecture?", "technical"),
+        ("Explain the vector embedding pipeline", "technical"),
+        ("What's the latency benchmark for graph retrieval?", "technical"),
+        ("Show me the implementation of typed retrieval", "technical"),
+        # generic (no clear match)
+        ("Hello there!", "generic"),
+        ("Tell me something interesting", "generic"),
+        ("What time is it?", "generic"),
+    ])
+    def test_intent_classification(self, query: str, expected: str):
+        assert self.classifier.classify(query) == expected
+
+    def test_fallback_to_generic(self):
+        """Completely ambiguous query → generic."""
+        assert self.classifier.classify("xyzzy plugh nothing") == "generic"
+
+    def test_empty_query_is_generic(self):
+        assert self.classifier.classify("") == "generic"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 2: _lane_label
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestLaneLabel:
+    """Unit tests for _lane_label helper."""
+
+    # ── Typed candidates ──────────────────────────────────────────────────
+
+    def test_typed_state_persona_bucket(self):
+        candidate = {
+            "_source": "typed_state",
+            "_original": {"bucket": "persona", "object_type": "identity"},
+        }
+        assert _lane_label(candidate) == "persona"
+
+    def test_typed_state_preference_bucket(self):
+        candidate = {
+            "_source": "typed_state",
+            "_original": {"bucket": "preference"},
+        }
+        assert _lane_label(candidate) == "preference"
+
+    def test_typed_state_operational_bucket(self):
+        candidate = {
+            "_source": "typed_state",
+            "_original": {"bucket": "operational"},
+        }
+        assert _lane_label(candidate) == "operational"
+
+    def test_typed_state_decision_bucket(self):
+        candidate = {
+            "_source": "typed_state",
+            "_original": {"bucket": "decision"},
+        }
+        assert _lane_label(candidate) == "decision"
+
+    def test_typed_procedure_decision_tag(self):
+        candidate = {
+            "_source": "typed_procedure",
+            "_original": {"object_type": "procedure", "tags": ["decision_framework"]},
+        }
+        assert _lane_label(candidate) == "decision"
+
+    def test_typed_state_engineering_tag(self):
+        candidate = {
+            "_source": "typed_state",
+            "_original": {"bucket": "", "tags": ["engineering"]},
+        }
+        assert _lane_label(candidate) == "engineering"
+
+    def test_typed_state_subject_preference_heuristic(self):
+        candidate = {
+            "_source": "typed_state",
+            "_original": {"bucket": "", "subject": "Yuan's favorite wine"},
+        }
+        assert _lane_label(candidate) == "preference"
+
+    def test_typed_state_subject_schedule_heuristic(self):
+        candidate = {
+            "_source": "typed_state",
+            "_original": {"bucket": "", "subject": "daily schedule routine"},
+        }
+        assert _lane_label(candidate) == "persona"
+
+    def test_typed_state_generic_fallback(self):
+        candidate = {
+            "_source": "typed_state",
+            "_original": {"bucket": "", "subject": "random thing"},
+        }
+        assert _lane_label(candidate) == "generic"
+
+    # ── Graph candidates ──────────────────────────────────────────────────
+
+    def test_graph_incident_entity_type(self):
+        candidate = {
+            "_source": "graph",
+            "entity_type": "incident",
+            "name": "prod outage",
+            "fact": "something broke",
+        }
+        assert _lane_label(candidate) == "incident"
+
+    def test_graph_engineering_keyword_in_name(self):
+        candidate = {
+            "_source": "graph",
+            "name": "feature flag wiring",
+            "fact": "ensuring feature flags are fully wired",
+        }
+        assert _lane_label(candidate) == "engineering"
+
+    def test_graph_engineering_tag(self):
+        candidate = {
+            "_source": "graph",
+            "name": "some fact",
+            "fact": "details about it",
+            "tags": ["architecture"],
+        }
+        assert _lane_label(candidate) == "engineering"
+
+    def test_graph_persona_keyword(self):
+        candidate = {
+            "_source": "graph",
+            "name": "favorite cuisine",
+            "fact": "yuan likes japanese food",
+        }
+        assert _lane_label(candidate) == "persona"
+
+    def test_graph_decision_keyword(self):
+        candidate = {
+            "_source": "graph",
+            "name": "decision on DB choice",
+            "fact": "chose FalkorDB for performance",
+        }
+        assert _lane_label(candidate) == "decision"
+
+    def test_graph_generic_fallback(self):
+        candidate = {
+            "_source": "graph",
+            "name": "some random thing",
+            "fact": "unrelated content",
+        }
+        assert _lane_label(candidate) == "generic"
+
+    # ── Unknown source ────────────────────────────────────────────────────
+
+    def test_unknown_source_generic(self):
+        candidate = {"_source": "unknown"}
+        assert _lane_label(candidate) == "generic"
+
+    def test_no_source_generic(self):
+        candidate = {}
+        assert _lane_label(candidate) == "generic"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 3: Suppression Matrix
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestSuppressionMatrix:
+    """Verify suppression matrix structure and content."""
+
+    def test_all_intents_present(self):
+        expected_intents = {
+            "persona", "preference", "operational", "technical",
+            "decision", "engineering", "incident", "generic",
+        }
+        assert set(SUPPRESSION_MATRIX.keys()) == expected_intents
+
+    def test_persona_suppresses_engineering_and_technical(self):
+        assert "engineering" in SUPPRESSION_MATRIX["persona"]
+        assert "technical" in SUPPRESSION_MATRIX["persona"]
+
+    def test_preference_suppresses_engineering_incident_operational(self):
+        assert "engineering" in SUPPRESSION_MATRIX["preference"]
+        assert "incident" in SUPPRESSION_MATRIX["preference"]
+        assert "operational" in SUPPRESSION_MATRIX["preference"]
+
+    def test_technical_suppresses_persona_preference(self):
+        assert "persona" in SUPPRESSION_MATRIX["technical"]
+        assert "preference" in SUPPRESSION_MATRIX["technical"]
+
+    def test_decision_suppresses_persona_preference(self):
+        assert "persona" in SUPPRESSION_MATRIX["decision"]
+        assert "preference" in SUPPRESSION_MATRIX["decision"]
+
+    def test_operational_suppresses_nothing(self):
+        assert SUPPRESSION_MATRIX["operational"] == []
+
+    def test_generic_suppresses_nothing(self):
+        assert SUPPRESSION_MATRIX["generic"] == []
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 4: rrf_merge_hybrid with suppression
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestRrfMergeHybridSuppression:
+    """Test lane suppression in rrf_merge_hybrid."""
+
+    def _build_mixed_pool(self):
+        """Build a candidate pool with engineering, persona, and generic items."""
+        graph_facts = [
+            _make_graph_fact("feature flag wiring", "ensuring feature flags are wired"),
+            _make_graph_fact("runtime version mismatch", "mismatched claims about version"),
+            _make_graph_fact("favorite cuisine", "yuan likes japanese food"),
+            _make_graph_fact("random context", "some generic information"),
+        ]
+        typed_state = [
+            _make_typed_state("Yuan's scheduling preference", bucket="persona"),
+            _make_typed_state("deploy pipeline", bucket="operational"),
+            _make_typed_state("wine taste", bucket="preference"),
+        ]
+        typed_procedures = [
+            _make_typed_procedure("rollback procedure", tags=["ops"]),
+        ]
+        return graph_facts, typed_state, typed_procedures
+
+    def test_persona_intent_suppresses_engineering(self):
+        """Persona query → engineering facts get zero score."""
+        graph_facts, typed_state, typed_procedures = self._build_mixed_pool()
+        results = rrf_merge_hybrid(
+            graph_facts=graph_facts,
+            typed_state=typed_state,
+            typed_procedures=typed_procedures,
+            max_facts=10,
+            query_intent="persona",
+            apply_diversity=False,
+        )
+        # Engineering facts should be at the bottom (zero score)
+        for r in results:
+            lane = _lane_label(r)
+            if lane == "engineering":
+                assert r["_hybrid_score"] == 0.0
+
+    def test_technical_intent_suppresses_persona_preference(self):
+        """Technical query → persona and preference candidates get zero score."""
+        graph_facts, typed_state, typed_procedures = self._build_mixed_pool()
+        results = rrf_merge_hybrid(
+            graph_facts=graph_facts,
+            typed_state=typed_state,
+            typed_procedures=typed_procedures,
+            max_facts=10,
+            query_intent="technical",
+            apply_diversity=False,
+        )
+        for r in results:
+            lane = _lane_label(r)
+            if lane in ("persona", "preference"):
+                assert r["_hybrid_score"] == 0.0
+
+    def test_generic_intent_no_suppression(self):
+        """Generic intent → all candidates keep their scores."""
+        graph_facts, typed_state, typed_procedures = self._build_mixed_pool()
+        results = rrf_merge_hybrid(
+            graph_facts=graph_facts,
+            typed_state=typed_state,
+            typed_procedures=typed_procedures,
+            max_facts=10,
+            query_intent="generic",
+            apply_diversity=False,
+        )
+        assert all(r["_hybrid_score"] > 0 for r in results)
+
+    def test_no_intent_param_no_suppression(self):
+        """No query_intent → backwards-compatible, no suppression."""
+        graph_facts, typed_state, typed_procedures = self._build_mixed_pool()
+        results = rrf_merge_hybrid(
+            graph_facts=graph_facts,
+            typed_state=typed_state,
+            typed_procedures=typed_procedures,
+            max_facts=10,
+            query_intent=None,
+            apply_diversity=False,
+        )
+        assert all(r["_hybrid_score"] > 0 for r in results)
+
+    def test_suppressed_candidates_sink_to_bottom(self):
+        """Zero-scored candidates sort after positive-scored ones."""
+        graph_facts, typed_state, typed_procedures = self._build_mixed_pool()
+        results = rrf_merge_hybrid(
+            graph_facts=graph_facts,
+            typed_state=typed_state,
+            typed_procedures=typed_procedures,
+            max_facts=10,
+            query_intent="persona",
+            apply_diversity=False,
+        )
+        # Find the first zero-scored result
+        scores = [r["_hybrid_score"] for r in results]
+        positive_scores = [s for s in scores if s > 0]
+        zero_scores = [s for s in scores if s == 0]
+        # All positives should come before zeros
+        if positive_scores and zero_scores:
+            last_positive_idx = max(i for i, s in enumerate(scores) if s > 0)
+            first_zero_idx = min(i for i, s in enumerate(scores) if s == 0)
+            assert last_positive_idx < first_zero_idx
+
+    def test_max_facts_contract_preserved(self):
+        """Output length never exceeds max_facts."""
+        graph_facts, typed_state, typed_procedures = self._build_mixed_pool()
+        results = rrf_merge_hybrid(
+            graph_facts=graph_facts,
+            typed_state=typed_state,
+            typed_procedures=typed_procedures,
+            max_facts=3,
+            query_intent="persona",
+            apply_diversity=False,
+        )
+        assert len(results) <= 3
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Section 5: Integration — HybridRetrievalService.merge with intent
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestHybridServiceMergeWithIntent:
+    """Test that merge() integrates query-intent classification."""
+
+    def test_merge_with_query_classifies_intent(self):
+        """merge(query=...) should classify and apply suppression."""
+        service = HybridRetrievalService()
+        graph_facts = [
+            _make_graph_fact("feature flag wiring", "ensuring feature flags are wired"),
+            _make_graph_fact("favorite cuisine", "yuan likes japanese food"),
+        ]
+        typed_results = {
+            "state": [_make_typed_state("Yuan's preference", bucket="persona")],
+            "procedures": [],
+        }
+        # Persona query — should suppress engineering
+        results = service.merge(
+            graph_facts=graph_facts,
+            typed_results=typed_results,
+            max_facts=10,
+            query="What are Yuan's favorite cuisines?",
+            apply_diversity=False,
+        )
+        # The engineering fact should be zero-scored
+        for r in results:
+            if _lane_label(r) == "engineering":
+                assert r["_hybrid_score"] == 0.0
+
+    def test_merge_without_query_no_suppression(self):
+        """merge(query=None) → no classification, backwards-compatible."""
+        service = HybridRetrievalService()
+        graph_facts = [
+            _make_graph_fact("feature flag wiring", "ensuring feature flags are wired"),
+        ]
+        typed_results = {"state": [], "procedures": []}
+        results = service.merge(
+            graph_facts=graph_facts,
+            typed_results=typed_results,
+            max_facts=10,
+            apply_diversity=False,
+        )
+        assert all(r["_hybrid_score"] > 0 for r in results)
+
+    def test_merge_uses_module_singleton_classifier(self):
+        """Verify merge() uses the module-level classifier singleton."""
+        _query_intent_classifier.clear_cache()
+        service = HybridRetrievalService()
+        service.merge(
+            graph_facts=[_make_graph_fact("test")],
+            typed_results={"state": [], "procedures": []},
+            max_facts=10,
+            query="What are Yuan's favorite cuisines?",
+            apply_diversity=False,
+        )
+        # After calling merge, the singleton cache should have an entry
+        key = hashlib.sha256(b"What are Yuan's favorite cuisines?").hexdigest()
+        assert key in _query_intent_classifier._cache
+        _query_intent_classifier.clear_cache()


### PR DESCRIPTION
## Option A Phase 2: Precision Uplift

Two-commit PR implementing Phase 2A (query-intent lane filter) and Phase 2B (RRF softening + candidate diversity) for the Option A Bicameral precision uplift.

### Phase 2A: Query-Intent Lane Filter
- **QueryIntentClassifier**: Rule-based regex classifier with 1hr SHA-256-keyed TTL cache. Classifies queries into: persona, preference, decision, operational, technical, generic.
- **`_lane_label()`**: Inspects candidate metadata (`_source`, entity type, tags, bucket) to assign lane labels.
- **Suppression matrix**: Maps intent → lanes to suppress (e.g., persona queries zero-score engineering/technical candidates).
- **`rrf_merge_hybrid()`**: New `query_intent` param; suppressed lane candidates get zero score before ranking.
- **`HybridRetrievalService.merge()`**: New `query` param; auto-classifies intent and passes to RRF merge.

### Phase 2B: RRF Softening + Diversity
- **`_HYBRID_RRF_K=60.0`**: Already calibrated from prior experiments (confirmed, no change needed).
- **`_dedup_candidates()`**: Jaccard token-overlap dedup with configurable threshold (default 0.85, env override `BICAMERAL_DEDUP_THRESHOLD`).
- **`_apply_mmr_diversity()`**: MMR re-ranking balancing relevance + diversity (default λ=0.3, env override `BICAMERAL_MMR_WEIGHT_DIVERSITY`).
- **`apply_diversity` param**: Dedup + MMR skipped when LLM reranker runs downstream.
- Graceful fallback: if dedup or MMR fails, logs warning and returns pool without that stage.

### Tests
- **104 new tests** across two files:
  - `test_hybrid_retrieval_lane_filter.py` (67 tests): classifier caching, 28 intent classifications, lane labeling, suppression logic, service integration
  - `test_hybrid_retrieval_diversity.py` (37 tests): Jaccard similarity, dedup, MMR, full pipeline integration, env var overrides
- All 162 related tests pass (including reranker + candidate contract tests).

### Backwards Compatibility
- `query_intent=None` (default) → no suppression, identical to prior behavior
- `apply_diversity=True` (default) → dedup + MMR applied; set False for reranker path
- `merge(query=None)` → no classification, backwards-compatible

**Parent epic**: Option A Precision Uplift  
**PRDs**: `EXEC-OPTION-A-QUERY-INTENT-LANE-FILTER-v1.md`, `EXEC-OPTION-A-FUSION-SOFTENING-DIVERSITY-v1.md`
